### PR TITLE
Update to the last version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v4.5.1
+        UPSTREAM_VERSION: 4.6.0+1
     restart: unless-stopped
     volumes:
       - "zcash:/home/zcash"


### PR DESCRIPTION
The way to install via apt install Linux command is different to the version, it would be v4.6.0+1 , linux does not accept - and you need to use + symbol