### PR TITLE
Change linux version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 ARG UPSTREAM_VERSION
 ENV ZCASH_DIR /home/zcash/.zcash
 ENV ZCASH_CONF ${ZCASH_DIR}/zcash.conf
 WORKDIR /home/zcash
 
-RUN apt-get update && apt-get -y install apt-transport-https wget gnupg2 && \ 
+RUN apt-get update && apt-get -y install apt-transport-https wget gnupg2 libc6 && \ 
     wget -qO - https://apt.z.cash/zcash.asc | apt-key add - && \
-    echo "deb [arch=amd64] https://apt.z.cash/ stretch main" | tee /etc/apt/sources.list.d/zcash.list && \
+    echo "deb [arch=amd64] https://apt.z.cash/ buster main" | tee /etc/apt/sources.list.d/zcash.list && \
     apt-get update && apt-get -y install -y zcash=${UPSTREAM_VERSION#v}
 
 RUN useradd -ms /bin/bash zcash && \

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcash.public.dappnode.eth",
   "version": "0.2.1",
-  "upstreamVersion": "v4.6.0-2",
+  "upstreamVersion": "v4.6.0+2",
   "shortDescription": "Zcash is a privacy-protecting, digital currency built on strong science.",
   "description": "Zcash is a privacy-protecting, digital currency built on strong science. Transact efficiently and safely with low fees while ensuring digital transactions remain private. Selectively share address and transaction information for auditing or regulatory compliance.",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v4.6.0-2
+        UPSTREAM_VERSION: v4.6.0+2
     restart: unless-stopped
     volumes:
       - "zcash:/home/zcash"


### PR DESCRIPTION
The strech version does not support the required version of libc6. In this PR we have changed stretch to buster.