### PR TITLE
Port standardization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,6 @@ services:
       ZCASH_RPCPASSWORD: dappnode
       ZCASH_RPCALLOWIP: 172.33.0.0/16
       ZCASH_RPCPORT: 8332
+      P2P_PORT: 8333
 volumes:
   zcash: {}

--- a/src/launch-zcashd.sh
+++ b/src/launch-zcashd.sh
@@ -140,7 +140,7 @@ EOF
 zcash-fetch-params 
 
 if [ $# -eq 0 ]; then
-    exec zcashd -printtoconsole
+    exec zcashd -port=${P2P_PORT} -printtoconsole
 else
     exec "$@"
 fi


### PR DESCRIPTION
- Included the p2p port env var and the flag port in the entrypoint, Zcash is based on bitccoind so, the option is the same that bitcoind uses
- Create env var P2P port