### PR TITLE
Update base image to bookworm

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 ARG UPSTREAM_VERSION
 ENV ZCASH_DIR /home/zcash/.zcash
 ENV ZCASH_CONF ${ZCASH_DIR}/zcash.conf
@@ -6,7 +6,7 @@ WORKDIR /home/zcash
 
 RUN apt-get update && apt-get -y install apt-transport-https wget gnupg2 libc6 && \ 
     wget -qO - https://apt.z.cash/zcash.asc | apt-key add - && \
-    echo "deb [arch=amd64] https://apt.z.cash/ buster main" | tee /etc/apt/sources.list.d/zcash.list && \
+    echo "deb [arch=amd64] https://apt.z.cash/ bookworm main" | tee /etc/apt/sources.list.d/zcash.list && \
     apt-get update && apt-get -y install -y zcash=${UPSTREAM_VERSION#v}
 
 RUN useradd -ms /bin/bash zcash && \


### PR DESCRIPTION
attempt to update to bookworm instead of buster, will revert to bullseye if bookworm doesnt work.